### PR TITLE
Enhance 3rd party translations warning

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -33,7 +33,7 @@ ram.build = "70M"
 ram.runtime = "10M"
 
 [antifeatures]
-arbitrary-limitations.en = "(Optional) In-line translations feature depends on 3rd party services"
+arbitrary-limitations.en = "(Optional) In-line translations feature depends on 3rd party services: Lingva API, a frontend for Google Translate hosted on phanpy.social."
 
 [install]
 


### PR DESCRIPTION
I had actually forgotten there already was a warning about translations being done by a 3rd party. While looking at the software behind that, I discovered it was an API for Lingva developed by Phanpy's developer, and hosted on lingva.phanpy.social. Lingva is itself an alternative frontend for Google Translate.

The use of lingva.phanpy.social as intermediary does anonymize the personal information towards Google Translate, but I thought it would be interesting to mention which are these third parties.