### PR TITLE
upgrade: mv and rm .files/.dirs to .build dir

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -12,6 +12,11 @@ ynh_setup_source --dest_dir="$install_dir" --full_replace
 
 mkdir "$install_dir/.build"
 mv $install_dir/* "$install_dir/.build"
+mv "$install_dir/.github" "$install_dir/.build"
+ynh_safe_rm "$install_dir/.env"
+mv "$install_dir/.env.production" "$install_dir/.build"
+mv "$install_dir/.gitattributes" "$install_dir/.build"
+mv "$install_dir/.gitignore" "$install_dir/.build"
 chown -R "$app:$app" "$install_dir/.build"
 
 #=================================================


### PR DESCRIPTION
in the upgrade script, `mv $install_dir/*` wasn't moving the hidden files and directories to the `$install_dir/.build` directory. Added commands to `mv` (or `ynh_safe_rm`, in the case of the `.env` file) them individually.